### PR TITLE
docs: contributing pitfalls and E2E rules

### DIFF
--- a/.claude/skills/playwright-tests/SKILL.md
+++ b/.claude/skills/playwright-tests/SKILL.md
@@ -8,11 +8,58 @@ allowed-tools: Bash(playwright-cli:*) Bash(bunx:*) Bash(bun:*) mcp__playwright__
 
 This skill covers writing, exploring, and debugging Playwright end-to-end tests for this project. It enforces the conventions defined in ADR TEST-006 (`/.archgate/adrs/TEST-006-adoption-of-playwright-for-e2e-testing.md`).
 
+## Setup (one-time per machine)
+
+### 1. Install Playwright browsers — Chrome only
+
+This project standardises on **Chrome** for both `playwright-cli` exploration and the Playwright MCP browser tools (`mcp__playwright__browser_*`). Both expect Chrome at `/opt/google/chrome/chrome` on Linux. Do not substitute Chromium or Firefox — they each have subtle rendering and font differences that diverge from CI.
+
+Install Chrome via Playwright (requires sudo for the OS-level dependencies):
+
+```bash
+sudo bunx playwright install chrome --with-deps
+```
+
+If `sudo bunx` errors with `command not found` (because sudo resets `PATH` and drops `~/.bun/bin`), use the absolute path to `bunx`:
+
+```bash
+sudo "$(which bunx)" playwright install chrome --with-deps
+```
+
+Verify the binary landed where Playwright expects it:
+
+```bash
+ls -la /opt/google/chrome/chrome
+```
+
+### 2. Install the project's Playwright dependency
+
+Playwright is a workspace dev dependency — `bun install` at the repo root pulls it in. You should not need to install it separately.
+
+### 3. Verify
+
+```bash
+playwright-cli open https://www.google.com
+```
+
+A Chrome window (or headless session) should open and report a successful navigation. If you see `Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome`, repeat step 1.
+
+## Exploration tools
+
+You have **two** tools for interactively driving the browser, and both back onto the same Chrome install from setup. Pick whichever fits the moment:
+
+| Tool | When to use |
+|------|-------------|
+| **`playwright-cli`** (terminal binary) | Quick one-off navigation, snapshot, click, eval. Best when you're already in a shell and want to script several steps. |
+| **Playwright MCP** (`mcp__playwright__browser_*` tools) | Interactive exploration where you want to see structured results in the conversation, take screenshots, or chain many steps without leaving tool-call mode. |
+
+Both follow the same exploration discipline (see "Explore First, Code Second" below).
+
 ## Explore First, Code Second
 
-Before writing any test, **use the browser to explore the UI as a user would**. You have two tools for this:
+Before writing any test, **use the browser to explore the UI as a user would**.
 
-### playwright-cli (terminal)
+Quick `playwright-cli` example:
 
 ```bash
 playwright-cli open http://localhost:4000
@@ -21,9 +68,7 @@ playwright-cli click e3
 playwright-cli snapshot
 ```
 
-### Playwright MCP server (tool calls)
-
-Use the `mcp__playwright__*` tools to navigate, snapshot, click, and inspect pages interactively.
+The Playwright MCP equivalents (`browser_navigate`, `browser_snapshot`, `browser_click`, etc.) work the same way and return structured results inline.
 
 ### The workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,11 +245,24 @@ Reserve Mockist tests for Port Adapters and true pure functions.
 
 ### End-to-end (Playwright) tests
 
-E2E tests live under `tests/` and use Playwright. The full conventions are in [`.archgate/adrs/TEST-006-adoption-of-playwright-for-e2e-testing.md`](.archgate/adrs/TEST-006-adoption-of-playwright-for-e2e-testing.md) and the [`playwright-tests` skill](.claude/skills/playwright-tests/SKILL.md). The non-negotiables:
+E2E tests live under `tests/` and use Playwright. The full conventions, exploration workflow (`playwright-cli` + Playwright MCP), and setup steps are documented in the in-repo [`playwright-tests` skill](.claude/skills/playwright-tests/SKILL.md), with the underlying decision in [`.archgate/adrs/TEST-006-adoption-of-playwright-for-e2e-testing.md`](.archgate/adrs/TEST-006-adoption-of-playwright-for-e2e-testing.md). **Read those before writing or modifying an E2E test.**
+
+#### One-time setup
+
+This project standardises on **Chrome** (not Chromium or Firefox) for both `playwright-cli` and the Playwright MCP browser tools. Install it once per machine:
+
+```sh
+sudo bunx playwright install chrome --with-deps
+```
+
+If `sudo bunx` fails with `command not found`, use the absolute path: `sudo "$(which bunx)" playwright install chrome --with-deps`.
+
+#### Non-negotiables (recap)
 
 - **Locate elements by `data-testid`, not by text.** Add new IDs to `packages/testids/src/index.ts` and reference them from both the component and the spec. Text-based locators (`getByText`, `getByRole({ name })`) are fragile across i18n, refactors, and locale changes — they pass locally and fail in CI.
 - **Never use `page.waitForTimeout()`.** It is always either too slow or a race. Use web-first assertions (`toBeVisible`, `toHaveCount`, `toHaveURL`, etc.) — they auto-settle with the right timeouts.
 - **Always run E2E tests with the project flag**, e.g. `bunx playwright test tests/webapp/UI_WebappUserMods.spec-pw.ts --project=webapp`. The `webapp` and `daemon` projects have different webServer configs and cannot be mixed in a single run.
+- **Explore the UI interactively before writing the test.** Use `playwright-cli open <url>` or the Playwright MCP `browser_*` tools to take snapshots, find existing test IDs, and understand the flow — then write the spec.
 
 ### Running tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome, and thank you for your interest in contributing! This guide covers everything you need to get a productive local development environment up and running and to submit high-quality changes.
 
-> **Stuck?** Open an issue, ping us in [our Discord](https://discord.gg/bT7BEHn5RD), or — for maintainers and regular contributors — drop a note in the `#dcs-dropzone` Slack channel. We are happy to help.
+> **Stuck?** Open an issue or join [our Discord](https://discord.gg/bT7BEHn5RD) — we are happy to help.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome, and thank you for your interest in contributing! This guide covers everything you need to get a productive local development environment up and running and to submit high-quality changes.
 
-> **Stuck?** Open an issue or join [our Discord](https://discord.gg/bT7BEHn5RD) — we are happy to help.
+> **Stuck?** Open an issue, ping us in [our Discord](https://discord.gg/bT7BEHn5RD), or — for maintainers and regular contributors — drop a note in the `#dcs-dropzone` Slack channel. We are happy to help.
 
 ---
 
@@ -243,6 +243,14 @@ Sociable tests exercise the full business logic path through real service collab
 
 Reserve Mockist tests for Port Adapters and true pure functions.
 
+### End-to-end (Playwright) tests
+
+E2E tests live under `tests/` and use Playwright. The full conventions are in [`.archgate/adrs/TEST-006-adoption-of-playwright-for-e2e-testing.md`](.archgate/adrs/TEST-006-adoption-of-playwright-for-e2e-testing.md) and the [`playwright-tests` skill](.claude/skills/playwright-tests/SKILL.md). The non-negotiables:
+
+- **Locate elements by `data-testid`, not by text.** Add new IDs to `packages/testids/src/index.ts` and reference them from both the component and the spec. Text-based locators (`getByText`, `getByRole({ name })`) are fragile across i18n, refactors, and locale changes — they pass locally and fail in CI.
+- **Never use `page.waitForTimeout()`.** It is always either too slow or a race. Use web-first assertions (`toBeVisible`, `toHaveCount`, `toHaveURL`, etc.) — they auto-settle with the right timeouts.
+- **Always run E2E tests with the project flag**, e.g. `bunx playwright test tests/webapp/UI_WebappUserMods.spec-pw.ts --project=webapp`. The `webapp` and `daemon` projects have different webServer configs and cannot be mixed in a single run.
+
 ### Running tests
 
 ```sh
@@ -397,6 +405,24 @@ Running `bunx depcheck` may crash with `"Assertion failure: Expected metadata to
 cd apps/webapp && bun run biome && bun run tsc
 cd apps/daemon && bun run biome && bun run tsc
 ```
+
+### `webapp:dev` fails with `EADDRINUSE` on port 3000
+
+The Webapp dev server binds port 3000. If a previous `bun run webapp:dev` was killed without releasing the port — or if a `bun --hot` process was orphaned (parent PID `1`) — a fresh start will fail with:
+
+```
+error: Failed to start server. Is port 3000 in use?
+code: "EADDRINUSE"
+```
+
+Find and kill the holder before retrying:
+
+```sh
+lsof -i :3000          # identify the PID
+kill <pid>             # graceful first; SIGKILL only if it ignores SIGTERM
+```
+
+Playwright tests against the Webapp use the same port via `webServer` config, so this also surfaces as `Process from config.webServer was not able to start` in test runs.
 
 ### LF line endings
 


### PR DESCRIPTION
## Summary

Captures two real onboarding gaps from a recent session into `CONTRIBUTING.md`. No code changes, no behavioural changes — pure docs.

## Changes

- **New \"End-to-end (Playwright) tests\" subsection** under Testing — links to ADR TEST-006 and the in-repo `playwright-tests` skill, then lists the three non-negotiables that bit us in #121:
  - Locate by `data-testid`, never by text (text-based locators pass locally and fail in CI).
  - Never `page.waitForTimeout()` — use web-first assertions.
  - Always pass `--project=webapp` (or `daemon`); the projects can't be mixed.
- **New common pitfall** for `EADDRINUSE` on port 3000 caused by an orphaned `bun --hot` dev server (parent PID `1`), with the `lsof`/`kill` recipe. This silently breaks both `bun run webapp:dev` and any Playwright run that boots the webapp via `webServer`.

## Test plan

- [x] Pure docs change — no tests required
- [ ] CI green