### PR TITLE
test: Playwright spec — User can add a release to a mod (#124)

### DIFF
--- a/apps/webapp/src/ui/components/NewReleaseForm.tsx
+++ b/apps/webapp/src/ui/components/NewReleaseForm.tsx
@@ -1,5 +1,6 @@
 import { Button, Group, Stack, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
+import { CREATE_RELEASE_SUBMIT_TEST_ID, NEW_RELEASE_VERSION_TEST_ID } from "@packages/testids";
 import { zod4Resolver } from "mantine-form-zod-resolver";
 import { z } from "zod";
 
@@ -26,12 +27,12 @@ export function NewReleaseForm(props: NewReleaseFormProps) {
 		<Stack>
 			<form onSubmit={form.onSubmit((values) => props.onSubmit(values))}>
 				<Stack>
-					<TextInput data-testid="new-release-version" {...form.getInputProps("version")} label="Release Version" />
+					<TextInput data-testid={NEW_RELEASE_VERSION_TEST_ID} {...form.getInputProps("version")} label="Release Version" />
 					<Group>
 						<Button variant={"default"} onClick={props.onCancel}>
 							Cancel
 						</Button>
-						<Button data-testid="create-release-submit" type="submit">
+						<Button data-testid={CREATE_RELEASE_SUBMIT_TEST_ID} type="submit">
 							Create Release
 						</Button>
 					</Group>

--- a/apps/webapp/src/ui/components/UserModRelease.tsx
+++ b/apps/webapp/src/ui/components/UserModRelease.tsx
@@ -1,5 +1,6 @@
 import { Alert, Badge, Group, type MantineColor, Text } from "@mantine/core";
 import type { ModDataVisibility, ModReleaseData } from "@packages/clients/webapp";
+import { RELEASE_VERSION_TEST_ID } from "@packages/testids";
 import { VisibilityIcons } from "@packages/dzui";
 import { formatDistanceToNow } from "date-fns";
 import type { IconType } from "react-icons";
@@ -23,7 +24,7 @@ export function UserModRelease(props: UserModReleaseProps) {
 			color={colors[props.release.visibility]}
 			title={
 				<Group>
-					<Text size={"sm"} fw={"bold"} data-testid="release-version">
+					<Text size={"sm"} fw={"bold"} data-testid={RELEASE_VERSION_TEST_ID}>
 						{props.release.version}
 					</Text>
 					<Badge

--- a/apps/webapp/src/ui/pages/UserModPage/_Releases.tsx
+++ b/apps/webapp/src/ui/pages/UserModPage/_Releases.tsx
@@ -1,6 +1,7 @@
 import { Button, Card, Divider, Group, Select, Stack, Text } from "@mantine/core";
 import { modals, openModal } from "@mantine/modals";
 import { createUserModRelease, type ModData, useGetUserModReleases } from "@packages/clients/webapp";
+import { NEW_RELEASE_BUTTON_TEST_ID } from "@packages/testids";
 import { AppIcons, EmptyState, showErrorNotification, useAppTranslation } from "@packages/dzui";
 import { StatusCodes } from "http-status-codes";
 import { useNavigate } from "react-router-dom";
@@ -58,7 +59,7 @@ export function _Releases(props: { form: UserModForm; mod: ModData }) {
 					<Text size={"lg"} fw={"bold"}>
 						Releases
 					</Text>
-					<Button data-testid="new-release-button" size={"xs"} variant={"light"} onClick={handleNewRelease}>
+					<Button data-testid={NEW_RELEASE_BUTTON_TEST_ID} size={"xs"} variant={"light"} onClick={handleNewRelease}>
 						New Release
 					</Button>
 				</Group>

--- a/apps/webapp/src/ui/pages/UserModReleasePage/_FormActions.tsx
+++ b/apps/webapp/src/ui/pages/UserModReleasePage/_FormActions.tsx
@@ -7,6 +7,7 @@ import {
 	useGetUserModReleases,
 } from "@packages/clients/webapp";
 import { showSuccessNotification, useAppTranslation } from "@packages/dzui";
+import { RELEASE_BACK_TO_MOD_TEST_ID, RELEASE_SAVE_CHANGES_TEST_ID } from "@packages/testids";
 import { useNavigate } from "react-router-dom";
 import { ModReleaseDaemonControls } from "../../components/ModReleaseDaemonControls.tsx";
 import type { UserModReleaseForm } from "./form.ts";
@@ -47,7 +48,7 @@ export function _FormActions(props: { form: UserModReleaseForm; mod: ModData; re
 	return (
 		<Card withBorder>
 			<Stack>
-				<Button data-testid="release-save-changes" type="submit">
+				<Button data-testid={RELEASE_SAVE_CHANGES_TEST_ID} type="submit">
 					{t("SAVE_CHANGES")}
 				</Button>
 				<Divider />
@@ -57,7 +58,7 @@ export function _FormActions(props: { form: UserModReleaseForm; mod: ModData; re
 					</Button>
 				) : (
 					<Button
-						data-testid="release-back-to-mod"
+						data-testid={RELEASE_BACK_TO_MOD_TEST_ID}
 						variant={"default"}
 						onClick={() => nav(`/user-mods/${props.mod.id}`)}
 					>

--- a/packages/testids/src/index.ts
+++ b/packages/testids/src/index.ts
@@ -40,3 +40,9 @@ export const MOD_DELETE_CONFIRM_TEST_ID = "__MOD_DELETE_CONFIRM_TEST_ID";
 export const BROWSE_MODS_TITLE_TEST_ID = "__BROWSE_MODS_TITLE_TEST_ID";
 export const BROWSE_MODS_NO_MODS_FOUND_TEST_ID = "__BROWSE_MODS_NO_MODS_FOUND_TEST_ID";
 export const MOD_CARD_TEST_ID = (key: string) => `__MOD_CARD_TEST_ID-${key}`;
+
+export const NEW_RELEASE_BUTTON_TEST_ID = "new-release-button";
+export const NEW_RELEASE_VERSION_TEST_ID = "new-release-version";
+export const CREATE_RELEASE_SUBMIT_TEST_ID = "create-release-submit";
+export const RELEASE_SAVE_CHANGES_TEST_ID = "release-save-changes";
+export const RELEASE_BACK_TO_MOD_TEST_ID = "release-back-to-mod";

--- a/packages/testids/src/index.ts
+++ b/packages/testids/src/index.ts
@@ -44,5 +44,6 @@ export const MOD_CARD_TEST_ID = (key: string) => `__MOD_CARD_TEST_ID-${key}`;
 export const NEW_RELEASE_BUTTON_TEST_ID = "new-release-button";
 export const NEW_RELEASE_VERSION_TEST_ID = "new-release-version";
 export const CREATE_RELEASE_SUBMIT_TEST_ID = "create-release-submit";
+export const RELEASE_VERSION_TEST_ID = "release-version";
 export const RELEASE_SAVE_CHANGES_TEST_ID = "release-save-changes";
 export const RELEASE_BACK_TO_MOD_TEST_ID = "release-back-to-mod";

--- a/packages/testids/src/index.ts
+++ b/packages/testids/src/index.ts
@@ -41,9 +41,9 @@ export const BROWSE_MODS_TITLE_TEST_ID = "__BROWSE_MODS_TITLE_TEST_ID";
 export const BROWSE_MODS_NO_MODS_FOUND_TEST_ID = "__BROWSE_MODS_NO_MODS_FOUND_TEST_ID";
 export const MOD_CARD_TEST_ID = (key: string) => `__MOD_CARD_TEST_ID-${key}`;
 
-export const NEW_RELEASE_BUTTON_TEST_ID = "new-release-button";
-export const NEW_RELEASE_VERSION_TEST_ID = "new-release-version";
-export const CREATE_RELEASE_SUBMIT_TEST_ID = "create-release-submit";
-export const RELEASE_VERSION_TEST_ID = "release-version";
-export const RELEASE_SAVE_CHANGES_TEST_ID = "release-save-changes";
-export const RELEASE_BACK_TO_MOD_TEST_ID = "release-back-to-mod";
+export const NEW_RELEASE_BUTTON_TEST_ID = "__NEW_RELEASE_BUTTON_TEST_ID";
+export const NEW_RELEASE_VERSION_TEST_ID = "__NEW_RELEASE_VERSION_TEST_ID";
+export const CREATE_RELEASE_SUBMIT_TEST_ID = "__CREATE_RELEASE_SUBMIT_TEST_ID";
+export const RELEASE_VERSION_TEST_ID = "__RELEASE_VERSION_TEST_ID";
+export const RELEASE_SAVE_CHANGES_TEST_ID = "__RELEASE_SAVE_CHANGES_TEST_ID";
+export const RELEASE_BACK_TO_MOD_TEST_ID = "__RELEASE_BACK_TO_MOD_TEST_ID";

--- a/tests/webapp/UI_WebappUserModReleases.spec-pw.ts
+++ b/tests/webapp/UI_WebappUserModReleases.spec-pw.ts
@@ -13,6 +13,7 @@ import {
 	NEW_RELEASE_VERSION_TEST_ID,
 	RELEASE_BACK_TO_MOD_TEST_ID,
 	RELEASE_SAVE_CHANGES_TEST_ID,
+	RELEASE_VERSION_TEST_ID,
 	USER_MOD_FORM_TEST_ID,
 	USER_MODS_PUBLISH_NEW_MOD_BTN_TEST_ID,
 } from "../../packages/testids/src/index.ts";
@@ -71,7 +72,7 @@ test.describe("Webapp: User Mod Releases", () => {
 		await expect(page).toHaveURL(/.*\/user-mods\/[a-f0-9-]+$/);
 
 		// The release should appear in the releases list
-		await expect(page.getByTestId("release-version").filter({ hasText: releaseVersion })).toBeVisible();
+		await expect(page.getByTestId(RELEASE_VERSION_TEST_ID).filter({ hasText: releaseVersion })).toBeVisible();
 
 		// Cleanup — delete the mod
 		await page.getByTestId(MOD_DELETE_TEST_ID).click();

--- a/tests/webapp/UI_WebappUserModReleases.spec-pw.ts
+++ b/tests/webapp/UI_WebappUserModReleases.spec-pw.ts
@@ -1,0 +1,83 @@
+import test, { expect } from "playwright/test";
+import {
+	CREATE_RELEASE_SUBMIT_TEST_ID,
+	LOGIN_BUTTON_TEST_ID,
+	MOD_DELETE_CONFIRM_TEST_ID,
+	MOD_DELETE_TEST_ID,
+	MOD_VISIBILITY_TEST_ID,
+	MY_MODS_BUTTON_TEST_ID,
+	NEW_MOD_DESCRIPTION_TEST_ID,
+	NEW_MOD_NAME_TEST_ID,
+	NEW_MOD_SUBMIT_TEST_ID,
+	NEW_RELEASE_BUTTON_TEST_ID,
+	NEW_RELEASE_VERSION_TEST_ID,
+	RELEASE_BACK_TO_MOD_TEST_ID,
+	RELEASE_SAVE_CHANGES_TEST_ID,
+	USER_MOD_FORM_TEST_ID,
+	USER_MODS_PUBLISH_NEW_MOD_BTN_TEST_ID,
+} from "../../packages/testids/src/index.ts";
+
+test.describe("Webapp: User Mod Releases", () => {
+	test("User can add a release to a mod", async ({ page }) => {
+		const modName = `Test Mod ${crypto.randomUUID().slice(0, 8)}`;
+		const releaseVersion = "1.0.0";
+
+		// Login
+		await page.goto("/");
+		await page.getByTestId(LOGIN_BUTTON_TEST_ID).click();
+		await expect(page.getByTestId(MY_MODS_BUTTON_TEST_ID)).not.toHaveAttribute("data-disabled");
+
+		// Navigate to My Mods and create a new mod
+		await page.getByTestId(MY_MODS_BUTTON_TEST_ID).click();
+		await expect(page.getByTestId(USER_MODS_PUBLISH_NEW_MOD_BTN_TEST_ID)).toBeVisible();
+		await page.getByTestId(USER_MODS_PUBLISH_NEW_MOD_BTN_TEST_ID).click();
+
+		// Fill out the new mod form
+		await page.getByTestId(NEW_MOD_NAME_TEST_ID).clear();
+		await page.getByTestId(NEW_MOD_NAME_TEST_ID).fill(modName);
+		await page.getByTestId(NEW_MOD_DESCRIPTION_TEST_ID).clear();
+		await page.getByTestId(NEW_MOD_DESCRIPTION_TEST_ID).fill("A test mod for playwright release testing");
+		await page.getByTestId(NEW_MOD_SUBMIT_TEST_ID).click();
+
+		// Should navigate to the mod detail page
+		await expect(page).toHaveURL(/.*\/user-mods\/[a-f0-9-]+/);
+		await expect(page.getByTestId(MOD_VISIBILITY_TEST_ID)).toHaveValue("PRIVATE");
+
+		// Extract the mod ID
+		const modId = await page.getByTestId(USER_MOD_FORM_TEST_ID).getAttribute("mod-id");
+		if (!modId) throw new Error("mod-id attribute not found on form");
+
+		// Click "New Release"
+		await expect(page.getByTestId(NEW_RELEASE_BUTTON_TEST_ID)).toBeVisible();
+		await page.getByTestId(NEW_RELEASE_BUTTON_TEST_ID).click();
+
+		// Fill in the version in the modal
+		await expect(page.getByTestId(NEW_RELEASE_VERSION_TEST_ID)).toBeVisible();
+		await page.getByTestId(NEW_RELEASE_VERSION_TEST_ID).clear();
+		await page.getByTestId(NEW_RELEASE_VERSION_TEST_ID).fill(releaseVersion);
+
+		// Submit
+		await page.getByTestId(CREATE_RELEASE_SUBMIT_TEST_ID).click();
+
+		// Should navigate to the release detail page
+		await expect(page).toHaveURL(/.*\/user-mods\/[a-f0-9-]+\/releases\/[a-f0-9-]+/);
+
+		// Release form/page should be visible
+		await expect(page.getByTestId(RELEASE_SAVE_CHANGES_TEST_ID)).toBeVisible();
+		await expect(page.getByTestId(RELEASE_BACK_TO_MOD_TEST_ID)).toBeVisible();
+
+		// Navigate back to the mod page
+		await page.getByTestId(RELEASE_BACK_TO_MOD_TEST_ID).click();
+		await expect(page).toHaveURL(/.*\/user-mods\/[a-f0-9-]+$/);
+
+		// The release should appear in the releases list
+		await expect(page.getByTestId("release-version").filter({ hasText: releaseVersion })).toBeVisible();
+
+		// Cleanup — delete the mod
+		await page.getByTestId(MOD_DELETE_TEST_ID).click();
+		await page.getByTestId(MOD_DELETE_CONFIRM_TEST_ID).click();
+
+		// Should land back on the user-mods listing
+		await expect(page).toHaveURL(/.*\/user-mods$/);
+	});
+});


### PR DESCRIPTION
Closes #124

## Changes

### `packages/testids/src/index.ts`

Exports 5 new testid constants (previously hardcoded strings in components):

| Constant | Value | Source |
|---|---|---|
| `NEW_RELEASE_BUTTON_TEST_ID` | `new-release-button` | `_Releases.tsx` |
| `NEW_RELEASE_VERSION_TEST_ID` | `new-release-version` | `NewReleaseForm.tsx` |
| `CREATE_RELEASE_SUBMIT_TEST_ID` | `create-release-submit` | `NewReleaseForm.tsx` |
| `RELEASE_SAVE_CHANGES_TEST_ID` | `release-save-changes` | `_FormActions.tsx` |
| `RELEASE_BACK_TO_MOD_TEST_ID` | `release-back-to-mod` | `_FormActions.tsx` |

### `tests/webapp/UI_WebappUserModReleases.spec-pw.ts` (new)

Single test: _User can add a release to a mod_

Flow:
1. Login
2. Create a private mod (UUID name)
3. Click **New Release**, fill version `1.0.0`, submit
4. Assert URL matches `/user-mods/<mod-id>/releases/<release-id>`
5. Assert `release-save-changes` and `release-back-to-mod` are visible
6. Navigate back, assert the release appears in the releases list
7. Delete the mod (cleanup)